### PR TITLE
Getting started with CI

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,6 @@
+^tic\.R$
+^appveyor\.yml$
+^\.travis\.yml$
 ^inst/js/node_modules/*$
 ^\.DS_Store$
 ^\.textlintrc$

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .Rhistory
 .RData
 .Rproj.user
-inst/js/node_modules/*
+inst/js/node_modules/
+.textlintr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+# Default configuration for use with tic package
+# Usually you shouldn't need to change the first part of the file
+
+# DO NOT CHANGE THE CODE BELOW
+before_install: R -q -e 'install.packages(c("remotes", "curl")); remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
+install: R -q -e 'tic::install()'
+after_install: R -q -e 'tic::after_install()'
+before_script: R -q -e 'tic::before_script()'
+script: R -q -e 'tic::script()'
+after_success: R -q -e 'tic::after_success()'
+after_failure: R -q -e 'tic::after_failure()'
+before_deploy: R -q -e 'tic::before_deploy()'
+deploy:
+  provider: script
+  script: R -q -e 'tic::deploy()'
+  on:
+    all_branches: true
+after_deploy: R -q -e 'tic::after_deploy()'
+after_script: R -q -e 'tic::after_script()'
+# DO NOT CHANGE THE CODE ABOVE
+
+# Custom parts:
+
+# Header
+language: r
+sudo: false
+dist: trusty
+cache: packages
+latex: false
+
+#env
+env:
+  global:
+  - _R_CHECK_FORCE_SUGGESTS_=false
+  - MAKEFLAGS="-j 2"
+
+#services
+services:

--- a/R/util.R
+++ b/R/util.R
@@ -1,0 +1,8 @@
+is_installed_dependencies <- function(target = c("npm", "textlint")) {
+
+  if (nchar(Sys.which(target)) == 0) {
+    FALSE
+  } else {
+    TRUE
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 textlintr
 =========
 
-[![CRAN status](https://www.r-pkg.org/badges/version/textlintr)](https://cran.r-project.org/package=textlintr) [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
+[![Travis-CI Build Status](https://travis-ci.org/uribo/textlintr.svg?branch=master)](https://travis-ci.org/uribo/textlintr) [![AppVeyor Build
+Status](https://ci.appveyor.com/api/projects/status/github/uribo/textlintr?branch=master&svg=true)](https://ci.appveyor.com/project/uribo/textlintr) [![CRAN status](https://www.r-pkg.org/badges/version/textlintr)](https://cran.r-project.org/package=textlintr) [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 
 The goal of textlintr is to ...
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,58 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  - ps: Bootstrap
+  - cmd: R -q -e "writeLines('options(repos = \'https://cloud.r-project.org\')', '~/.Rprofile')"
+  - cmd: R -q -e "getOption('repos')"
+  - cmd: R -q -e "install.packages('remotes'); remotes::install_github('ropenscilabs/tic'); tic::prepare_all_stages()"
+
+cache:
+- C:\RLibrary
+
+before_build: R -q -e "tic::before_install()"
+build_script: R -q -e "tic::install()"
+after_build: R -q -e "tic::after_install()"
+before_test: R -q -e "tic::before_script()"
+test_script: R -q -e "tic::script()"
+on_success: R -q -e "try(tic::after_success(), silent = TRUE)"
+on_failure: R -q -e "tic::after_failure()"
+before_deploy: R -q -e "tic::before_deploy()"
+deploy_script: R -q -e "tic::deploy()"
+after_deploy: R -q -e "tic::after_deploy()"
+on_finish: R -q -e "tic::after_script()"
+
+# Adapt as necessary starting from here
+
+#on_failure:
+#  - 7z a failure.zip *.Rcheck\*
+#  - appveyor PushArtifact failure.zip
+
+#environment:
+#  GITHUB_PAT:
+#    secure: VXO22OHLkl4YhVIomSMwCZyOTx03Xf2WICaVng9xH7gISlAg8a+qrt1DtFtk8sK5
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(textlintr)
+
+test_check("textlintr")

--- a/tests/testthat/test-textlint-ecosystems.R
+++ b/tests/testthat/test-textlint-ecosystems.R
@@ -8,6 +8,7 @@ test_that("Get started", {
     is_installed_dependencies("textlint")
   )
   skip_on_travis()
+  skip_on_appveyor()
   expect_false(
     is_installed_dependencies("yarn")
   )

--- a/tests/testthat/test-textlint-ecosystems.R
+++ b/tests/testthat/test-textlint-ecosystems.R
@@ -1,0 +1,13 @@
+context("test-textlint-ecosystems")
+
+test_that("Get started", {
+  expect_true(
+    is_installed_dependencies("npm")
+  )
+  expect_false(
+    is_installed_dependencies("textlint")
+  )
+  expect_false(
+    is_installed_dependencies("yarn")
+  )
+})

--- a/tests/testthat/test-textlint-ecosystems.R
+++ b/tests/testthat/test-textlint-ecosystems.R
@@ -7,6 +7,7 @@ test_that("Get started", {
   expect_false(
     is_installed_dependencies("textlint")
   )
+  skip_on_travis()
   expect_false(
     is_installed_dependencies("yarn")
   )

--- a/tic.R
+++ b/tic.R
@@ -1,0 +1,15 @@
+add_package_checks()
+
+if (Sys.getenv("id_rsa") != "") {
+  # pkgdown documentation can be built optionally. Other example criteria:
+  # - `inherits(ci(), "TravisCI")`: Only for Travis CI
+  # - `ci()$is_tag()`: Only for tags, not for branches
+  # - `Sys.getenv("BUILD_PKGDOWN") != ""`: If the env var "BUILD_PKGDOWN" is set
+  # - `Sys.getenv("TRAVIS_EVENT_TYPE") == "cron"`: Only for Travis cron jobs
+  get_stage("before_deploy") %>%
+    add_step(step_setup_ssh())
+
+  get_stage("deploy") %>%
+    add_step(step_build_pkgdown()) %>%
+    add_step(step_push_deploy(path = "docs", branch = "gh-pages"))
+}


### PR DESCRIPTION
## Summary

継続的インテグレーション (CI) のため

- [Travis CI](https://travis-ci.com/uribo/textlintr/) (UNIX)
- [Appveyor](https://ci.appveyor.com/project/uribo/textlintr/) (Windows)

の2つを導入。ステータスは[README.md](https://github.com/uribo/textlintr/blob/e008f68c97ab7e265540efe6b41129921ed55e44/README.md)で確認できる。

CIが通った後、[{tic}](https://github.com/ropenscilabs/tic/)によるGitHub pagesのビルド([gh-pagesブランチ](https://github.com/uribo/textlintr/tree/gh-pages))を実行可能にした。

## Related Issues

#2 (CI and tic)