### PR TITLE
💄 Update console output style

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,8 @@ Description: What the package does (one paragraph).
 License: MIT + file LICENSE
 SystemRequirements: textlint (https://textlint.github.io/) for pluggable linting tool.
 Imports:
+    cli (>= 1.0.0),
+    crayon (>= 1.3.4),
     jsonlite (>= 1.5),
     processx (>= 3.2.0),
     rlang (>= 0.2.2),

--- a/R/textlint.R
+++ b/R/textlint.R
@@ -25,22 +25,7 @@ textlint <- function(file = NULL, lintrc = ".textlintrc") {
     rlang::inform("Great! There is no place to modify. ")
   } else {
 
-    markers <-
-      unname(apply(lint_res_parsed, 1, function(x) {
-        marker <- list()
-        marker$type <- "style"
-        marker$file <- input_full_path
-        marker$line <- as.numeric(x["line"])
-        marker$column <- as.numeric(x["column"])
-        marker$message <- as.character(x["message"])
-        marker
-      }))
-
-    rstudioapi::callFun("sourceMarkers",
-                        name       = "textlintr",
-                        markers    = markers,
-                        basePath   = NULL,
-                        autoSelect = "first")
+    rstudio_source_markers(input_full_path, lint_res_parsed)
   }
 }
 
@@ -89,4 +74,23 @@ lint_parse <- function(lint_res) {
       gsub("\\[\\{\"messages\":", "", lint_res$stdout))
 
   jsonlite::fromJSON(lint_res)
+}
+
+rstudio_source_markers <- function(input_full_path, lint_res_parsed) {
+  markers <-
+    unname(apply(lint_res_parsed, 1, function(x) {
+      marker <- list()
+      marker$type <- "style"
+      marker$file <- input_full_path
+      marker$line <- as.numeric(x["line"])
+      marker$column <- as.numeric(x["column"])
+      marker$message <- as.character(x["message"])
+      marker
+    }))
+
+  rstudioapi::callFun("sourceMarkers",
+                      name       = "textlintr",
+                      markers    = markers,
+                      basePath   = NULL,
+                      autoSelect = "first")
 }

--- a/R/textlint.R
+++ b/R/textlint.R
@@ -16,7 +16,7 @@ textlint <- function(file = NULL, lintrc = ".textlintrc") {
     normalizePath(file)
 
   lint_res <-
-    lint_exec(input_full_path, lintrc)
+    lint_exec(input_full_path, lintrc, "json")
 
   lint_res_parsed <-
     lint_parse(lint_res)
@@ -44,10 +44,14 @@ textlint <- function(file = NULL, lintrc = ".textlintrc") {
   }
 }
 
-lint_exec <- function(file = NULL, lintrc = ".textlintrc") {
+lint_exec <- function(file = NULL, lintrc = ".textlintrc",
+                      format = c("json", "checkstyle", "compact", "jslint-xml",
+                                 "junit", "pretty-error", "stylish",
+                                 "table", "tap", "unix")) {
   if (rlang::is_false(file.exists(lintrc)))
     rlang::abort("Missing .textlintrc.\nYou can setup by update_lint_rules()")
 
+  rlang::arg_match(format)
   input_full_path <-
     normalizePath(file)
 
@@ -62,10 +66,14 @@ lint_exec <- function(file = NULL, lintrc = ".textlintrc") {
       "textlint"
     }
 
+  if (rlang::is_true(length(format)) > 1)
+    format <- "json"
+
   lint_res <-
     processx::run(command = exec_textlint_path,
-                  args = c("-f", "json", input_full_path),
-                  error_on_status = FALSE)
+                  args = c("-f", format, input_full_path),
+                  error_on_status = FALSE,
+                  echo = FALSE)
 
   lint_res$input_full_path <-
     input_full_path

--- a/man/textlint.Rd
+++ b/man/textlint.Rd
@@ -4,12 +4,16 @@
 \alias{textlint}
 \title{Textlint a given file}
 \usage{
-textlint(file = NULL, lintrc = ".textlintrc")
+textlint(file = NULL, lintrc = ".textlintrc", markers = TRUE)
 }
 \arguments{
 \item{file}{filename whose target to textlint}
 
 \item{lintrc}{file path to .textlintrc. Default, searcing from current directory.}
+
+\item{markers}{modified output format. If \code{true}, the result of lint is
+displayed in RStudio's marker panel (Only when running with RStudio version higher
+than 0.99.225).}
 }
 \description{
 Textlint a given file

--- a/tests/testthat/test-textlint.R
+++ b/tests/testthat/test-textlint.R
@@ -1,0 +1,14 @@
+context("test-textlint")
+
+test_that("Check text", {
+
+  skip_on_appveyor()
+  withr::with_dir(
+    tempdir(), {
+      update_lint_rules(c("common-misspellings", "preset-jtf-style", "no-todo"))
+      lint_res <-
+        capture.output(textlint(system.file("sample.md", package = "textlintr"),
+                                markers = FALSE))
+      expect_length(lint_res, 6L)
+    })
+})


### PR DESCRIPTION
## Summary

**cli**と**crayon**を導入し、コンソールでの修正点を表示するようにした。

![image](https://user-images.githubusercontent.com/228649/46595743-e2397180-cb14-11e8-80e6-65ae7cf5909a.png)

### textlint -fオプションへの対応

本家が採用している出力形式に対応した。ただし、`lint_exec()` はエクスポートされている関数ではないので、ユーザが選択することはできない。使っているのは`json`。

https://github.com/uribo/textlintr/blob/01a3c26f8904c08f2c0efe06c75ccd7b99b5c03a/R/textlint.R#L42-L44

https://github.com/uribo/textlintr/blob/01a3c26f8904c08f2c0efe06c75ccd7b99b5c03a/R/textlint.R#L22

https://github.com/uribo/textlintr/blob/01a3c26f8904c08f2c0efe06c75ccd7b99b5c03a/R/textlint.R#L63-L64

`pretty-error`形式での出力は綺麗で修正箇所がわかりやすいが、既存の処理（json形式をdata.frameに変換しているので）との相性が悪いので自前でフォーマットを行うことにした (d88e847)。

![image](https://user-images.githubusercontent.com/228649/46595819-38a6b000-cb15-11e8-90f2-9918e011b7c2.png)


### `textlint()`用のテストを追加

これまではmarkersだけの出力だったが、コンソール上へ結果を出力できるようになったため、`textlint()`のテストを追加した。

https://github.com/uribo/textlintr/blob/01a3c26f8904c08f2c0efe06c75ccd7b99b5c03a/tests/testthat/test-textlint.R#L5-L13


## Related issues

none.