### PR TITLE
🔖 Update npm in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 FROM rocker/tidyverse:3.5.1
 
+ENV npm_version=6.4.1
 RUN set -x && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     curl \
-    gnupg \
-    wget && \
+    gnupg && \
   curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && \
   apt-get install -y --no-install-recommends \
     nodejs \
     npm && \
   apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  npm install npm@${npm_version} -g && \
+  rm -rf /tmp/npm-*
 
 RUN set -x && \
   install2.r --error \


### PR DESCRIPTION
## Summary

開発用のDocker環境で使っているnpmのバージョンが古いのでアップデート。現時点での最新版 ([`6.4.1`](https://github.com/npm/cli/releases/tag/v6.4.1))を入れた。

## Related issues

Close #10