### PR TITLE
Added overwrite option to `update_lint_rules()`

### DIFF
--- a/R/textlintrc.R
+++ b/R/textlintrc.R
@@ -36,17 +36,26 @@ init_textlintr <- function(rules = "common-misspellings") {
 }
 
 #' Update .textlintrc
+#'
+#' @description Update the rule file (`.texlintrc`) which textlint checks.
+#' To adopt the rule of the character string specified as argument. When
+#' `NULL` is given, all installed rules are applied.
 #' @inherit init_textlintr
 #' @rdname update_lint_rules
 #' @examples
 #' \dontrun{
+#'
+#' update_lint_rules()
 #' update_lint_rules(rules = "common-misspellings")
 #' }
 #' @export
-update_lint_rules <- function(rules = "common-misspellings") {
+update_lint_rules <- function(rules = NULL) {
 
-  if (nchar(rules)[1] == 0)
-    rlang::abort("Please specify at least one rule.")
+  if (rlang::is_null(rules))
+    rules <-
+      sapply(
+        dir(".textlintr/node_modules/", pattern = "^textlint-rule-"),
+        function(x) gsub("textlint-rule-", "", x))
 
   writeLines(
     jsonlite::prettify(

--- a/man/update_lint_rules.Rd
+++ b/man/update_lint_rules.Rd
@@ -4,10 +4,15 @@
 \alias{update_lint_rules}
 \title{Update .textlintrc}
 \usage{
-update_lint_rules(rules = NULL)
+update_lint_rules(rules = NULL, lintrc = ".textlintrc",
+  overwrite = FALSE)
 }
 \arguments{
 \item{rules}{lint rule}
+
+\item{lintrc}{file path to .textlintrc. Default, searcing from current directory.}
+
+\item{overwrite}{logical. If set \code{TRUE}, existing rules will be overwritten by the input rules.}
 }
 \description{
 Update the rule file (\code{.texlintrc}) which textlint checks.
@@ -16,8 +21,11 @@ To adopt the rule of the character string specified as argument. When
 }
 \examples{
 \dontrun{
-
+# Registrate all installed rules
 update_lint_rules()
-update_lint_rules(rules = "common-misspellings")
+# Added a rule
+update_lint_rules(rules = "common-misspellings", overwrite = FALSE)
+# Overwite rules
+update_lint_rules(rules = "common-misspellings", overwrite = TRUE)
 }
 }

--- a/man/update_lint_rules.Rd
+++ b/man/update_lint_rules.Rd
@@ -4,16 +4,20 @@
 \alias{update_lint_rules}
 \title{Update .textlintrc}
 \usage{
-update_lint_rules(rules = "common-misspellings")
+update_lint_rules(rules = NULL)
 }
 \arguments{
 \item{rules}{lint rule}
 }
 \description{
-Update .textlintrc
+Update the rule file (\code{.texlintrc}) which textlint checks.
+To adopt the rule of the character string specified as argument. When
+\code{NULL} is given, all installed rules are applied.
 }
 \examples{
 \dontrun{
+
+update_lint_rules()
 update_lint_rules(rules = "common-misspellings")
 }
 }

--- a/tests/testthat/test-rules.R
+++ b/tests/testthat/test-rules.R
@@ -10,17 +10,19 @@ test_that(".textlintrc works", {
   withr::with_dir(
     tempdir(), {
       update_lint_rules(rules = c("common-misspellings",
-                                  "preset-jtf-style"))
+                                  "preset-jtf-style"),
+                        overwrite = TRUE)
       res <-
         configure_lint_rules(".textlintrc", open = FALSE)
       expect_is(res, "list")
       expect_length(res, 2)
       expect_named(res, c("common-misspellings",
                           "preset-jtf-style"))
-      update_lint_rules(rules = c("preset-ja-technical-writing"))
+      update_lint_rules(rules = c("preset-jtf-style"),
+                        overwrite = TRUE)
       res <-
         configure_lint_rules()
-      expect_named(res, c("preset-ja-technical-writing"))
+      expect_named(res, c("preset-jtf-style"))
       expect_true(res[[1]])
     }
   )

--- a/tests/testthat/test-rules.R
+++ b/tests/testthat/test-rules.R
@@ -9,11 +9,6 @@ test_that(".textlintrc works", {
 
   withr::with_dir(
     tempdir(), {
-      expect_error(
-        update_lint_rules(rules = ""),
-        "Please specify at least one rule."
-      )
-
       update_lint_rules(rules = c("common-misspellings",
                                   "preset-jtf-style"))
       res <-

--- a/tests/testthat/test-textlint-ecosystems.R
+++ b/tests/testthat/test-textlint-ecosystems.R
@@ -14,31 +14,14 @@ test_that("Get started", {
   )
 })
 
-test_that("We enable modify a .textlintrc", {
-  withr::with_dir(
-    tempdir(), {
-      update_lint_rules(rules = "common-misspellings")
-      expect_equal(
-        nchar(paste(readLines(".textlintrc"), collapse = "")),
-        180L
-      )
-    })
-  withr::with_dir(
-    tempdir(), {
-      update_lint_rules(c("common-misspellings", "no-todo", "preset-jtf-style"))
-      expect_equal(
-        nchar(paste(readLines(".textlintrc"), collapse = "")),
-        237L
-      )
-    })
-})
-
 test_that("Activate on textlint", {
 
   skip_on_appveyor()
   withr::with_dir(
     tempdir(), {
-      init_textlintr()
+      init_textlintr(c("common-misspellings",
+                       "preset-jtf-style",
+                       "no-todo"))
       expect_true(
         dir.exists(".textlintr")
       )
@@ -46,11 +29,20 @@ test_that("Activate on textlint", {
         init_textlintr(),
         "Already, exits textlint.js"
       )
-
+      writeLines(
+        jsonlite::prettify(
+          paste0(
+            '{"rules": {',
+            paste0("\"", "common-misspellings", "\"", ": true", collapse = ","),
+            '},"plugins": {"@textlint/markdown": {
+      "extensions": [".Rmd"]}}}')),
+        ".textlintrc"
+      )
       textlint_res_raw <-
         processx::run(
           command = ".textlintr/node_modules/textlint/bin/textlint.js",
           args = c("-f", "json",
+                   "--rule", "common-misspellings",
                    normalizePath(
                      system.file("sample.md", package = "textlintr"))),
           error_on_status = FALSE)
@@ -61,6 +53,14 @@ test_that("Activate on textlint", {
       expect_length(
         textlint_res_raw,
         4
+      )
+      expect_equal(
+        textlint_res_raw$status,
+        1
+      )
+      expect_match(
+        textlint_res_raw$stdout,
+        ".messages.+type.+lint.+ruleId.+common-misspellings"
       )
       skip_if(dir.exists(".textlintr"))
       expect_false(

--- a/tests/testthat/test-textlint.R
+++ b/tests/testthat/test-textlint.R
@@ -5,7 +5,8 @@ test_that("Check text", {
   skip_on_appveyor()
   withr::with_dir(
     tempdir(), {
-      update_lint_rules(c("common-misspellings", "preset-jtf-style", "no-todo"))
+      update_lint_rules(c("common-misspellings", "preset-jtf-style", "no-todo"),
+                        overwrite = TRUE)
       lint_res <-
         capture.output(textlint(system.file("sample.md", package = "textlintr"),
                                 markers = FALSE))
@@ -31,6 +32,11 @@ test_that("Check text", {
                     format = c("json", "pretty-error")
         )
         )
+      )
+      update_lint_rules(overwrite = TRUE)
+      expect_equal(
+        nchar(paste(readLines(".textlintrc"), collapse = "")),
+        208L
       )
     })
 })


### PR DESCRIPTION
## Summary

`update_lint_rules()`では、引数rulesに与えられたルールを有効化するものだった。ただ、これでは実行時に対象のルールを列挙する必要があり効率が悪かった。

<details>

```r
# 従来の方法
update_lint_rules("no-todo")
jsonlite::read_json(".textlintrc")
# $rules
# $rules$`no-todo`
# [1] TRUE
# 
# 
# $plugins
# $plugins$`@textlint/markdown`
# $plugins$`@textlint/markdown`$extensions
# $plugins$`@textlint/markdown`$extensions[[1]]
# [1] ".Rmd"

update_lint_rules("common-misspellings")
jsonlite::read_json(".textlintrc")
# $rules
# $rules$`common-misspellings`
# [1] TRUE
# 
# 
# $plugins
# $plugins$`@textlint/markdown`
# $plugins$`@textlint/markdown`$extensions
# $plugins$`@textlint/markdown`$extensions[[1]]
# [1] ".Rmd"
```

</details>

新しい挙動では

1. `rules = NULL`が与えられた時に、`.textlintr/node_modules/`にインストールされた全てのルールを有効化する。
2. `rule`に与えられたルールが追加される
2. `overwite = TRUE`とした時はルールが上書きされる

<details>

```r
devtools::load_all()
init_textlintr(c("common-misspellings", "preset-jtf-style", "no-todo"))

update_lint_rules()
jsonlite::read_json(".textlintrc")
# $rules
# $rules$`no-todo`
# [1] TRUE
# 
# $rules$`common-misspellings`
# [1] TRUE
# 
# $rules$helper
# [1] TRUE
# 
# $rules$`preset-jtf-style`
# [1] TRUE
# 
# $rules$prh
# [1] TRUE
# 
# 
# $plugins
# $plugins$`@textlint/markdown`
# $plugins$`@textlint/markdown`$extensions
# [1] ".Rmd"

update_lint_rules("no-todo", overwrite = TRUE)
jsonlite::read_json(".textlintrc")
# $rules
# $rules$`no-todo`
# [1] TRUE
# 
# 
# $plugins
# $plugins$`@textlint/markdown`
# $plugins$`@textlint/markdown`$extensions
# $plugins$`@textlint/markdown`$extensions[[1]]
# [1] ".Rmd"

update_lint_rules("common-misspellings")
# jsonlite::read_json(".textlintrc")
# $rules
# $rules$`no-todo`
# [1] TRUE
# 
# $rules$`common-misspellings`
# [1] TRUE
# 
# 
# $plugins
# $plugins$`@textlint/markdown`
# $plugins$`@textlint/markdown`$extensions
# [1] ".Rmd"
```

</details>

となっている。


## Related Issues

none.