### PR TITLE
Don't use textlint.js in global

### DIFF
--- a/R/textlint.R
+++ b/R/textlint.R
@@ -46,19 +46,14 @@ lint_exec <- function(file = NULL, lintrc = ".textlintrc",
   input_full_path <-
     normalizePath(file)
 
+    if (rlang::is_false(is_installed_dependencies("textlint")))
+      rlang::abort("Setup is not complete or textlint is not installed in the global.\nFirst, use init_textlintr() to install textlint.") # nocov # nolint
+
   exec_textlint_path <-
-    if (is_installed_dependencies("textlint") == FALSE) {
-      if (file.exists(".textlintr/node_modules/textlint/bin/textlint.js") == TRUE) { # nolint
-        ".textlintr/node_modules/textlint/bin/textlint.js"
-      } else {
-        rlang::abort("Setup is not complete or textlint is not installed in the global.\nFirst, use init_textlintr() to install textlint.") # nocov nolint
-      }
-    } else {
-      "textlint" # nocov
-    }
+          ".textlintr/node_modules/textlint/bin/textlint.js"
 
   if (rlang::is_true(length(format) > 1)) {
-    rlang::warn("The string to give to format must be one.\n'json' is forcibly applied.")
+    rlang::warn("The string to give to format must be one.\n'json' is forcibly applied.") # nolint
     format <- "json"
   }
 

--- a/R/textlintrc.R
+++ b/R/textlintrc.R
@@ -12,8 +12,8 @@ init_textlintr <- function(rules = "common-misspellings") {
   if (rlang::is_false(is_installed_dependencies("npm")))
     rlang::abort("Can not find: npm") # nocov
 
-  if (is_installed_dependencies("textlint") == FALSE) {
-    if (dir.exists(".textlintr") == FALSE) {
+  # Install textlit, rules, and copy .textlintr
+  if (rlang::is_false(is_installed_dependencies("textlint"))) {
       dir.create(".textlintr")
 
       df_dep_rules <-
@@ -48,7 +48,6 @@ init_textlintr <- function(rules = "common-misspellings") {
 
     } else {
       rlang::inform("Already, exits textlint.js")
-    }
   }
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -1,8 +1,8 @@
 is_installed_dependencies <- function(target = c("npm", "textlint")) {
-
-  if (nchar(Sys.which(target)) == 0) {
+  if (nchar(Sys.which(target)) == 0 && !file.exists(".textlintr/node_modules/textlint/bin/textlint.js")) { # nolint
     FALSE
-  } else {
+  }
+  else {
     TRUE
   }
 }

--- a/tests/testthat/test-textlint-ecosystems.R
+++ b/tests/testthat/test-textlint-ecosystems.R
@@ -19,12 +19,18 @@ test_that("Activate on textlint", {
   skip_on_appveyor()
   withr::with_dir(
     tempdir(), {
-      # skip_if(dir.exists(".textlintr/node_modules/"))
-      init_textlintr(c("common-misspellings",
-                       "preset-jtf-style",
-                       "no-todo"))
+      skip_if(dir.exists(".textlintr/"))
+      expect_message(
+        init_textlintr(c("common-misspellings",
+                         "preset-jtf-style",
+                         "no-todo")),
+        "Install was successful"
+      )
       expect_true(
         dir.exists(".textlintr")
+      )
+      expect_true(
+        file.exists(".textlintr/node_modules/textlint/bin/textlint.js")
       )
       expect_silent(
         check_rule_exist()
@@ -32,21 +38,6 @@ test_that("Activate on textlint", {
       expect_message(
         init_textlintr(),
         "Already, exits textlint.js"
-      )
-      validity_rules <-
-        configure_lint_rules()
-      expect_is(
-        validity_rules,
-        "list"
-      )
-      expect_length(
-        validity_rules,
-        3L
-      )
-      expect_named(
-        validity_rules,
-        c("common-misspellings", "preset-jtf-style", "no-todo"),
-        ignore.order = TRUE
       )
       textlint_res_raw <-
         processx::run(
@@ -59,10 +50,6 @@ test_that("Activate on textlint", {
       expect_is(
         textlint_res_raw,
         "list"
-      )
-      expect_length(
-        textlint_res_raw,
-        4
       )
       expect_equal(
         textlint_res_raw$status,
@@ -82,7 +69,8 @@ test_that("Activate on textlint", {
       )
       expect_named(
         validity_rules,
-        c("common-misspellings", "helper", "no-todo", "preset-jtf-style", "prh"),
+        c("common-misspellings", "helper",
+          "no-todo", "preset-jtf-style", "prh"),
         ignore.order = TRUE
       )
       expect_true(is_rule_exist("preset-jtf-style"))
@@ -96,6 +84,10 @@ test_that("Activate on textlint", {
           "no-todo", "preset-jtf-style", "prh"),
         ignore.order = TRUE
       )
+      expect_equal(
+        nchar(paste(readLines(".textlintrc"), collapse = "")),
+        242L
+      )
       processx::run(
         command = "npm",
         args = c("uninstall",
@@ -103,7 +95,11 @@ test_that("Activate on textlint", {
                  " --save"),
         wd = ".textlintr",
         error_on_status = FALSE)
-
+      update_lint_rules(overwrite = TRUE)
+      expect_equal(
+        nchar(paste(readLines(".textlintrc"), collapse = "")),
+        208L
+      )
       skip_if(dir.exists(".textlintr"))
       expect_false(
         dir.exists(".textlintr")

--- a/tests/testthat/test-textlint-ecosystems.R
+++ b/tests/testthat/test-textlint-ecosystems.R
@@ -97,9 +97,11 @@ test_that("Activate on textlint", {
         ignore.order = TRUE
       )
       processx::run(
-        command = ".textlintr/node_modules/textlint/bin/textlint.js",
+        command = "npm",
         args = c("uninstall",
-                 "textlint-rule-first-sentence-length"),
+                 "textlint-rule-first-sentence-length",
+                 " --save"),
+        wd = ".textlintr",
         error_on_status = FALSE)
 
       skip_if(dir.exists(".textlintr"))

--- a/tests/testthat/test-textlint.R
+++ b/tests/testthat/test-textlint.R
@@ -5,8 +5,11 @@ test_that("Check text", {
   skip_on_appveyor()
   withr::with_dir(
     tempdir(), {
-      update_lint_rules(c("common-misspellings", "preset-jtf-style", "no-todo"),
-                        overwrite = TRUE)
+      expect_silent(
+        update_lint_rules(
+          c("common-misspellings", "preset-jtf-style", "no-todo"),
+          overwrite = TRUE)
+      )
       lint_res <-
         capture.output(textlint(system.file("sample.md", package = "textlintr"),
                                 markers = FALSE))
@@ -32,11 +35,6 @@ test_that("Check text", {
                     format = c("json", "pretty-error")
         )
         )
-      )
-      update_lint_rules(overwrite = TRUE)
-      expect_equal(
-        nchar(paste(readLines(".textlintrc"), collapse = "")),
-        242L
       )
     })
 })


### PR DESCRIPTION
## Summary

- textlintのパス設定に不備があった点を修正
- `textlint()`で使われるtextlint.jsは`init_textlintr()`実行時にインストールされるものに制御
- テストの実行順番を考慮し、testthatの内容を変更

## Related Issues

#15 