### PR TITLE
Convert `processx::run()` to `system()` when runing`npm` command

### DIFF
--- a/R/rules.R
+++ b/R/rules.R
@@ -123,14 +123,14 @@ match_rules <- function(rules) {
   search_res <-
     lapply(rule_sets(rules),
            function(x) {
-             processx::run("npm",
-                           args = c("search", "--json", x),
-                           echo_cmd = FALSE)
+             paste0(system(paste(Sys.which("npm"),
+                                 "search", "--json", x),
+                           intern = TRUE),
+                    collapse = "\n")
            })
-
     purrr::map(purrr::map(
-      purrr::keep(search_res, ~ .x$status == 0),
-      ~ jsonlite::fromJSON(.x$stdout)[c("name", "version")]),
+      purrr::keep(search_res, ~ length(.x) != 0),
+      ~ jsonlite::fromJSON(.)[c("name", "version")]),
       ~ subset(.x, grepl("^textlint-rule-", .x$name)))
 }
 
@@ -174,13 +174,13 @@ add_rules <- function(rules = NULL) {
     pretty = TRUE
   )
   exec_res <-
-    processx::run(Sys.which("npm"),
-                args = c("install"),
-                wd = ".textlintr")
-  if (exec_res$status == 1)
+    paste0(system(paste(Sys.which("npm"),
+                 "--prefix ./.textlintr install ./.textlintr"),
+           intern = TRUE),
+           collapse = "\n")
+  if (length(exec_res) == 0)
     rlang::abort("Oops, can not install packages")
-
-  if (exec_res$status == 0)
+  else
     rlang::inform(crayon::green("installed packages"))
 }
 

--- a/R/rules.R
+++ b/R/rules.R
@@ -189,8 +189,10 @@ add_rules <- function(rules = NULL) {
 #' @inheritParams init_textlintr
 #' @rdname is_rule_exist
 #' @examples
+#' \dontrun{
 #' is_rule_exist("no-todo")
 #' is_rule_exist("first-sentence-length")
+#' }
 #' @export
 is_rule_exist <- function(rules) {
 

--- a/R/textlintrc.R
+++ b/R/textlintrc.R
@@ -37,9 +37,8 @@ init_textlintr <- function(rules = "common-misspellings") {
         pretty = TRUE
       )
 
-      processx::run(Sys.which("npm"),
-                    args = c("install"),
-                    wd = ".textlintr")
+      system(paste(Sys.which("npm"),
+                   "--prefix ./.textlintr install ./.textlintr"))
       update_lint_rules(rules)
       writeLines("*\n!/.gitignore",
                  ".textlintr/.gitignore")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,34 +9,28 @@ init:
 
 install:
   - ps: Bootstrap
-  - cmd: R -q -e "writeLines('options(repos = \'https://cloud.r-project.org\')', '~/.Rprofile')"
-  - cmd: R -q -e "getOption('repos')"
-  - cmd: R -q -e "install.packages('remotes'); remotes::install_github('ropenscilabs/tic'); tic::prepare_all_stages()"
+  - set PATH=%APPDATA%\npm;%PATH%
 
 cache:
 - C:\RLibrary
 
-before_build: R -q -e "tic::before_install()"
-build_script: R -q -e "tic::install()"
-after_build: R -q -e "tic::after_install()"
-before_test: R -q -e "tic::before_script()"
-test_script: R -q -e "tic::script()"
-on_success: R -q -e "try(tic::after_success(), silent = TRUE)"
-on_failure: R -q -e "tic::after_failure()"
-before_deploy: R -q -e "tic::before_deploy()"
-deploy_script: R -q -e "tic::deploy()"
-after_deploy: R -q -e "tic::after_deploy()"
-on_finish: R -q -e "tic::after_script()"
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  - travis-tool.sh run_tests
+
+# Don't actually build.
+build: off
 
 # Adapt as necessary starting from here
 
 #on_failure:
 #  - 7z a failure.zip *.Rcheck\*
 #  - appveyor PushArtifact failure.zip
-
-#environment:
-#  GITHUB_PAT:
-#    secure: VXO22OHLkl4YhVIomSMwCZyOTx03Xf2WICaVng9xH7gISlAg8a+qrt1DtFtk8sK5
 
 artifacts:
   - path: '*.Rcheck\**\*.log'

--- a/inst/js/package.json
+++ b/inst/js/package.json
@@ -1,7 +1,9 @@
 {
+  "private": true,
   "name": "textlintr",
   "version": "0.0.1",
-  "description": "",
+  "description": "Natural Language Linter Tools for 'R Markdown' and R Code",
+  "license": "MIT + file LICENSE",
   "devDependencies": {
     "textlint": "^11.0.0",
     "textlint-rule-common-misspellings": "^1.0.1",

--- a/man/is_rule_exist.Rd
+++ b/man/is_rule_exist.Rd
@@ -13,6 +13,8 @@ is_rule_exist(rules)
 Check if rule is installed
 }
 \examples{
+\dontrun{
 is_rule_exist("no-todo")
 is_rule_exist("first-sentence-length")
+}
 }


### PR DESCRIPTION
## Summary

Appveyor上での`npm install`や`npm search`を実行する際は、processxを使わずに`system()`で実行する。これはCIを通すために必要

## Related Issues

Closed #5 